### PR TITLE
fix: correct error handling for non-200 status codes

### DIFF
--- a/nodes/Puppeteer/Puppeteer.node.ts
+++ b/nodes/Puppeteer/Puppeteer.node.ts
@@ -320,10 +320,11 @@ export class Puppeteer implements INodeType {
 				const statusCode = response?.status();
 
 				if (statusCode !== 200) {
-					if (this.continueOnFail() !== true) {
+					if (this.continueOnFail() === true) {
 						returnItem = [
 							{
 								json: {
+									error: `Request failed with status code ${statusCode}`,
 									headers,
 									statusCode,
 								},


### PR DESCRIPTION
When Continue(using error output) is enabled, errors are now properly routed through the Error output instead of Success output.

Fixes #43